### PR TITLE
Fix RTL layout for app logos cell

### DIFF
--- a/Sources/AutomatticAbout/AutomatticAppLogosCell.swift
+++ b/Sources/AutomatticAbout/AutomatticAppLogosCell.swift
@@ -32,14 +32,27 @@ class AutomatticAppLogosCell: UITableViewCell {
         contentView.addSubview(spriteKitView)
         spriteKitView.translatesAutoresizingMaskIntoConstraints = false
 
-        NSLayoutConstraint.activate([
+        configureConstraints()
+    }
+
+    private func configureConstraints() {
+        let edgeConstraints: [NSLayoutConstraint] = [
+            contentView.leadingAnchor.constraint(equalTo: spriteKitView.leadingAnchor),
+            contentView.trailingAnchor.constraint(equalTo: spriteKitView.trailingAnchor)
+        ]
+        edgeConstraints.forEach({ $0.priority = .defaultLow })
+
+        var constraints: [NSLayoutConstraint] = [
             contentView.leadingAnchor.constraint(lessThanOrEqualTo: spriteKitView.leadingAnchor),
             contentView.trailingAnchor.constraint(greaterThanOrEqualTo: spriteKitView.trailingAnchor),
             contentView.topAnchor.constraint(equalTo: spriteKitView.topAnchor),
             contentView.bottomAnchor.constraint(equalTo: spriteKitView.bottomAnchor),
             spriteKitView.widthAnchor.constraint(lessThanOrEqualToConstant: Metrics.maxWidth),
             spriteKitView.centerXAnchor.constraint(equalTo: contentView.centerXAnchor)
-        ])
+        ]
+        constraints.append(contentsOf: edgeConstraints)
+
+        NSLayoutConstraint.activate(constraints)
     }
 
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {


### PR DESCRIPTION
The previous layout constraints for the app logo cell's SpriteKitView created an ambiguous horizontal layout. This had the result of the cell not having any width (and not being visible) in right-to-left layouts. 

This PR adds two extra constraints to ensure that the cell is visible in all cases.

| Before | After |
|---|---|
| ![Simulator Screen Shot - iPhone 13 Pro - 2021-12-10 at 12 12 22](https://user-images.githubusercontent.com/4780/145573548-42ec9d80-4723-4301-a009-f445488a3877.png) | ![Simulator Screen Shot - iPhone 13 Pro - 2021-12-10 at 11 38 52](https://user-images.githubusercontent.com/4780/145573552-e045cd14-11a3-410f-87eb-d7dc52aeabd6.png) |

**To test**

* Test using the associated WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/17663