### PR TITLE
Disable haptics when logos cell is not visible

### DIFF
--- a/Example/Example.xcodeproj/project.pbxproj
+++ b/Example/Example.xcodeproj/project.pbxproj
@@ -321,7 +321,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.automattic.Example;
+				PRODUCT_BUNDLE_IDENTIFIER = com.automattic.AboutScreenExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
@@ -349,7 +349,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.automattic.Example;
+				PRODUCT_BUNDLE_IDENTIFIER = com.automattic.AboutScreenExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;

--- a/Sources/AutomatticAbout/AutomatticAboutScreen.swift
+++ b/Sources/AutomatticAbout/AutomatticAboutScreen.swift
@@ -163,6 +163,10 @@ public class AutomatticAboutScreen: UIViewController {
     override public func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
 
+        for cell in tableView.visibleCells {
+            attemptToSetHapticState(.paused, for: cell)
+        }
+
         if isMovingFromParent || isBeingDismissedDirectlyOrByAncestor() {
             configuration.didHide(viewController: self)
         }
@@ -170,6 +174,10 @@ public class AutomatticAboutScreen: UIViewController {
 
     override public func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
+
+        for cell in tableView.visibleCells {
+            attemptToSetHapticState(.active, for: cell)
+        }
 
         navigationController?.setNavigationBarHidden(!shouldShowNavigationBar, animated: true)
 
@@ -193,6 +201,16 @@ public class AutomatticAboutScreen: UIViewController {
 
         headerView.frame.size.height = headerView.systemLayoutSizeFitting(UIView.layoutFittingCompressedSize).height
         tableView.tableHeaderView = headerView
+    }
+
+    /// If the provided cell is an AutomatticAppLogosCell, set the haptic state to the requested one.
+    ///
+    private func attemptToSetHapticState(_ state: HapticsState, for cell: UITableViewCell) {
+        guard let cell = cell as? AutomatticAppLogosCell else {
+            return
+        }
+
+        cell.hapticsState = state
     }
 
     // MARK: - Actions
@@ -244,13 +262,6 @@ extension AutomatticAboutScreen: UITableViewDataSource {
         return cell
     }
 
-    public func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
-        let section = sections[indexPath.section]
-        let item = section[indexPath.row]
-
-        cell.separatorInset = item.hidesSeparator ? UIEdgeInsets(top: 0, left: 0, bottom: 0, right: .greatestFiniteMagnitude) : tableView.separatorInset
-    }
-
     public func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
         let section = sections[indexPath.section]
         let item = section[indexPath.row]
@@ -271,6 +282,19 @@ extension AutomatticAboutScreen: UITableViewDelegate {
         item.action?(context)
 
         tableView.deselectRow(at: indexPath, animated: true)
+    }
+
+    public func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
+        let section = sections[indexPath.section]
+        let item = section[indexPath.row]
+
+        cell.separatorInset = item.hidesSeparator ? UIEdgeInsets(top: 0, left: 0, bottom: 0, right: .greatestFiniteMagnitude) : tableView.separatorInset
+
+        attemptToSetHapticState(.active, for: cell)
+    }
+
+    public func tableView(_ tableView: UITableView, didEndDisplaying cell: UITableViewCell, forRowAt indexPath: IndexPath) {
+        attemptToSetHapticState(.paused, for: cell)
     }
 }
 

--- a/Sources/AutomatticAbout/AutomatticAppLogosCell.swift
+++ b/Sources/AutomatticAbout/AutomatticAppLogosCell.swift
@@ -2,10 +2,23 @@ import UIKit
 import SpriteKit
 import CoreMotion
 
+
+enum HapticsState {
+    case active
+    case paused
+}
+
 /// A table view cell that contains a SpriteKit game scene which shows logos
 /// of the various apps from Automattic.
 ///
 class AutomatticAppLogosCell: UITableViewCell {
+
+    var hapticsState: HapticsState = .active {
+        didSet {
+            logosScene.hapticsState = hapticsState
+        }
+    }
+
     private var logosScene: AppLogosScene!
     private var spriteKitView: SKView!
 
@@ -105,6 +118,8 @@ private class AppLogosScene: SKScene {
     // Haptics
     fileprivate var softGenerator = UIImpactFeedbackGenerator(style: .soft)
     fileprivate var rigidGenerator = UIImpactFeedbackGenerator(style: .rigid)
+
+    var hapticsState: HapticsState = .active
 
     // Keeps track of the last time a specific physics body made contact.
     // Used to limit the number of haptics impacts we trigger as a result of collisions.
@@ -297,6 +312,10 @@ private class AppLogosScene: SKScene {
 
 extension AppLogosScene: SKPhysicsContactDelegate {
     func didBegin(_ contact: SKPhysicsContact) {
+        guard hapticsState == .active else {
+            return
+        }
+
         let currentTime = CACurrentMediaTime()
 
         // If we trigger a haptics impact for every single impact it feels a bit much,


### PR DESCRIPTION
This PR disables haptics on the About screen when the cell containing the app logos is not visible.

Please test using the associated WPiOS PR. Full testing instructions are available there: https://github.com/wordpress-mobile/WordPress-iOS/pull/17686