### PR TITLE
Clear app logos scene background to allow for different cell backgrounds

### DIFF
--- a/Sources/AutomatticAbout/AutomatticAppLogosCell.swift
+++ b/Sources/AutomatticAbout/AutomatticAppLogosCell.swift
@@ -150,7 +150,7 @@ private class AppLogosScene: SKScene {
     // MARK: - Scene creation
 
     private func generateScene() {
-        backgroundColor = .secondarySystemGroupedBackground
+        backgroundColor = .clear
 
         let edge = SKPhysicsBody(edgeLoopFrom: frame)
         edge.categoryBitMask = edgeCategory


### PR DESCRIPTION
The background of the app logos SpriteKit defaults to white, which may not work well for apps that customise the background colours they use in table views. This PR sets the background to clear, so that the table cell backgrounds can show through.

| Before | After |
|---|---|
| ![Simulator Screen Shot - iPhone 13 Pro - 2021-12-20 at 11 31 55](https://user-images.githubusercontent.com/4780/146763566-0c606fff-7883-47ab-9184-cec0f18d19bb.png) | ![Simulator Screen Shot - iPhone 13 Pro - 2021-12-20 at 11 52 57](https://user-images.githubusercontent.com/4780/146763574-1e324933-3728-4824-863a-a6642bcf1e08.png) |

I'll roll this into the next release I do to include the recent [haptics fix](https://github.com/Automattic/AutomatticAbout-Swift/pull/4).

**To Test**

* Clone this repository, and open the root directory in Xcode. In the App Delegate of the example app, override the default table view cell background color by adding this to `application:didFinishLaunching:`

```
UITableViewCell.appearance().backgroundColor = .gray
```
* Build and run the example app (the simulator is fine). Ensure that the background of the app logos cell matches the rest of the cell it's contained in.